### PR TITLE
By setting homepage to './', we make all links use './' as their base

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "envoy",
   "version": "0.1.0",
+  "homepage": "./",
   "private": true,
   "dependencies": {
     "@material-ui/core": "^3.0.3",


### PR DESCRIPTION
This means we can deploy to static assets, and the base in the path is
handled for us by the browser.  (That is, for built file foo/bar, we go
to
https://ismith-envoy.darksa.com/dxhnmi7ueelovzhmne3ehexnhrs/igjfmosym2/foo/bar
instead of https://ismith-envoy.darksa.com/foo/bar)